### PR TITLE
Fix trapezoidal velocity trajectory generation time scaling

### DIFF
--- a/test/trajectory/test_trapezoidal_trajectory.py
+++ b/test/trajectory/test_trapezoidal_trajectory.py
@@ -13,7 +13,7 @@ def test_single_dof_trajectory():
 
     # Check that the segments are as follows:
     # 2-segment, 0-segment (no motion), 2-segment, 3-segment
-    assert len(traj.segment_times) == 5
+    assert len(traj.segment_times) == 4
     traj_0 = traj.single_dof_trajectories[0]
     assert len(traj_0.times) == 8
     assert not np.any(np.abs(traj_0.velocities) > qd_max)


### PR DESCRIPTION
In the previous implementation, every trajectory used its own limits by only ensuring it *finished* at the same time. While this worked, it means that technically all the degrees of freedom were not synced up.

In this PR, we change the logic to make sure that a single time scaling is computed with the most limiting speed/acceleration in consideration, and then use that for all degrees of freedom.

This ends up simplifying the math significantly, as there is no longer a quadratic to solve!

