### PR TITLE
Replace importlib's deprecated path function with files

### DIFF
--- a/src/pyroboplan/models/utils.py
+++ b/src/pyroboplan/models/utils.py
@@ -13,4 +13,5 @@ def get_example_models_folder():
         str
             The path to the `pyroboplan` example models folder.
     """
-    return importlib.resources.path(pyroboplan, "models").as_posix()
+    resource_path = importlib.resources.files(pyroboplan) / "models"
+    return resource_path.as_posix()


### PR DESCRIPTION
As noted in https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy, `importlib.resources.path` has been deprecated. This causes an error on my machine when running examples. Updating to the recommended interface resolves it.

e.g.

```
>>> import importlib.resources
>>> importlib.resources.path(pyroboplan, "models")
<stdin>:1: DeprecationWarning: path is deprecated. Use files() instead. Refer to https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy for migration advice.
>>>
>>> importlib.resources.files(pyroboplan) / "models"
PosixPath('/Users/eholum/Development/Robotics/pyroboplan/src/pyroboplan/models')
```