### PR TITLE
Add an option keep planning after goal is reached in RRT

### DIFF
--- a/examples/example_rrt.py
+++ b/examples/example_rrt.py
@@ -40,12 +40,13 @@ if __name__ == "__main__":
     options = RRTPlannerOptions(
         max_angle_step=0.05,
         max_connection_dist=0.25,
-        goal_biasing_probability=0.15,
-        max_planning_time=10.0,
         rrt_connect=False,
         bidirectional_rrt=False,
         rrt_star=False,
         max_rewire_dist=3.0,
+        max_planning_time=10.0,
+        fast_return=True,
+        goal_biasing_probability=0.15,
     )
 
     planner = RRTPlanner(model, collision_model, options=options)

--- a/src/pyroboplan/planning/graph.py
+++ b/src/pyroboplan/planning/graph.py
@@ -191,6 +191,8 @@ class Graph:
     def get_nearest_node(self, q):
         """
         Gets the nearest node to a specified robot configuration.
+        If the configuration is in the graph the corresponding node will be returned. Namely,
+        the node with distance 0.
 
         Parameters
         ----------
@@ -204,6 +206,9 @@ class Graph:
         """
         nearest_node = None
         min_dist = np.inf
+        chk_node = Node(q)
+        if chk_node in self.nodes:
+            return self.nodes[chk_node]
 
         for node in self.nodes:
             dist = configuration_distance(q, node.q)

--- a/src/pyroboplan/planning/rrt.py
+++ b/src/pyroboplan/planning/rrt.py
@@ -228,6 +228,10 @@ class RRTPlanner:
             q_sample : array-like
                 The robot configuration sample to extend or connect towards.
         """
+        # If the are the same node there's nothing to do.
+        if np.array_equal(parent_node.q, q_sample):
+            return None
+
         q_diff = q_sample - parent_node.q
         q_increment = self.options.max_connection_dist * q_diff / np.linalg.norm(q_diff)
 

--- a/src/pyroboplan/planning/rrt.py
+++ b/src/pyroboplan/planning/rrt.py
@@ -28,6 +28,7 @@ class RRTPlannerOptions:
         rrt_star=False,
         max_rewire_dist=np.inf,
         max_planning_time=10.0,
+        fast_return=True,
         goal_biasing_probability=0.0,
     ):
         """
@@ -53,6 +54,9 @@ class RRTPlannerOptions:
                 If set to `np.inf`, all nodes in the trees will be considered for rewiring.
             max_planning_time : float
                 Maximum planning time, in seconds.
+            fast_return : bool
+                If True, return as soon as a solution is found. Otherwise continuing building the tree
+                until max_planning_time is reached.
             goal_biasing_probability : float
                 Probability of sampling the goal configuration itself, which can help planning converge.
         """
@@ -63,6 +67,7 @@ class RRTPlannerOptions:
         self.rrt_star = rrt_star
         self.max_rewire_dist = max_rewire_dist
         self.max_planning_time = max_planning_time
+        self.fast_return = fast_return
         self.goal_biasing_probability = goal_biasing_probability
 
 
@@ -143,11 +148,16 @@ class RRTPlanner:
             goal_found = True
 
         start_tree_phase = True
-        while not goal_found:
+        while True:
+            # Only return on success if specified in the options.
+            if goal_found and self.options.fast_return:
+                break
+
             # Check for timeouts.
             if time.time() - t_start > self.options.max_planning_time:
+                message = "succeeded" if goal_found else "timed out"
                 print(
-                    f"Planning timed out after {self.options.max_planning_time} seconds."
+                    f"Planning {message} after {self.options.max_planning_time} seconds."
                 )
                 break
 


### PR DESCRIPTION
Noting that RRT* and some other flavors will converge to the optimal path as the sample size approaches infinity, I added a `fast_return` option to the planner so that sampling/rewiring can continue even if a path has been found.

While I was at it I noted the divide by zero error when extending from the sampled goal pose to the goal pose. It's an edge case but I figured it should be explicit... 