### PR TITLE
Use the same random seed when comparing RRT and RRT* in tests

### DIFF
--- a/test/planning/test_rrt.py
+++ b/test/planning/test_rrt.py
@@ -100,6 +100,8 @@ def test_plan_rrt_star():
     path_original = planner.plan(q_start, q_goal)
 
     # Then, plan with RRT* enabled (use maximum rewire distance for effect).
+    # Note we need to reset the seed so the nominal plans are equivalent.
+    np.random.seed(1234)
     options.rrt_star = True
     options.max_rewire_dist = np.inf
     planner = RRTPlanner(model, collision_model, options=options)


### PR DESCRIPTION
Whoops. I think we were just getting lucky with RNG with this until the recent refactors.

Anyways, if we are comparing RRT and RRT*, the random seed must be the same in both cases. Else we're comparing apples to horses.

To verify this, I ran the `test_plan_rrt_star()` test a bunch of times, using a different seed each time (but the same between both planner variations). Worked every time. This was not the case before this change.