### PR TITLE
Add path shortcutting capability

### DIFF
--- a/examples/example_collision_along_path.py
+++ b/examples/example_collision_along_path.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
     q_start = pinocchio.randomConfiguration(model)
     q_end = pinocchio.randomConfiguration(model)
     max_angle_step = 0.05
-    q_path = discretize_joint_space_path(q_start, q_end, max_angle_step)
+    q_path = discretize_joint_space_path([q_start, q_end], max_angle_step)
 
     # Visualize the path
     target_tforms = extract_cartesian_poses(model, "panda_hand", q_path)

--- a/examples/example_prm.py
+++ b/examples/example_prm.py
@@ -10,7 +10,10 @@ import time
 
 from pinocchio.visualize import MeshcatVisualizer
 
-from pyroboplan.core.utils import extract_cartesian_poses, get_random_collision_free_state
+from pyroboplan.core.utils import (
+    extract_cartesian_poses,
+    get_random_collision_free_state,
+)
 from pyroboplan.planning.path_shortcutting import shortcut_path
 from pyroboplan.planning.prm import PRMPlanner, PRMPlannerOptions
 from pyroboplan.planning.utils import (
@@ -60,20 +63,22 @@ def run_prm_search(q_start, q_end, planner, options, ee_name, max_retries=5):
     # Animate the path
     if path:
         planner.visualize(viz, ee_name, show_path=True, show_graph=True)
-        
+
         # Optionally shortcut the path
         do_shortcutting = True
         if do_shortcutting:
             path = shortcut_path(model, collision_model, path)
-    
-        discretized_path =  discretize_joint_space_path(path, options.max_angle_step)
+
+        discretized_path = discretize_joint_space_path(path, options.max_angle_step)
 
         if do_shortcutting:
-            target_tforms = extract_cartesian_poses(model, "panda_hand", discretized_path)
+            target_tforms = extract_cartesian_poses(
+                model, "panda_hand", discretized_path
+            )
             visualize_frames(
                 viz, "shortened_path", target_tforms, line_length=0.05, line_width=1.5
             )
-    
+
         input("Press 'Enter' to animate the path.")
         q_path = discretize_joint_space_path(path, options.max_angle_step)
         for q in q_path:

--- a/examples/example_prm.py
+++ b/examples/example_prm.py
@@ -65,7 +65,7 @@ def run_prm_search(q_start, q_end, planner, options, ee_name, max_retries=5):
         planner.visualize(viz, ee_name, show_path=True, show_graph=True)
 
         # Optionally shortcut the path
-        do_shortcutting = True
+        do_shortcutting = False
         if do_shortcutting:
             path = shortcut_path(model, collision_model, path)
 

--- a/examples/example_rrt.py
+++ b/examples/example_rrt.py
@@ -53,6 +53,28 @@ if __name__ == "__main__":
     path = planner.plan(q_start, q_end)
     planner.visualize(viz, "panda_hand", show_tree=True)
 
+    do_shortcutting = True
+    if do_shortcutting:
+        from pyroboplan.core.utils import extract_cartesian_poses
+        from pyroboplan.planning.path_shortcutting import shortcut_path
+        from pyroboplan.visualization.meshcat_utils import visualize_frames
+
+        path = shortcut_path(model, collision_model, path)
+
+        # TODO: Factor to reusable function
+        q_path = []
+        for idx in range(1, len(path)):
+            q_start = path[idx - 1]
+            q_goal = path[idx]
+            q_path = q_path + discretize_joint_space_path(
+                q_start, q_goal, options.max_angle_step
+            )
+
+        target_tforms = extract_cartesian_poses(model, "panda_hand", q_path)
+        visualize_frames(
+            viz, "shortened_path", target_tforms, line_length=0.05, line_width=1.5
+        )
+
     # Animate the path
     if path:
         input("Press 'Enter' to animate the path.")

--- a/examples/example_rrt.py
+++ b/examples/example_rrt.py
@@ -6,14 +6,16 @@ Rapidly-Exploring Random Tree (RRT) algorithm.
 from pinocchio.visualize import MeshcatVisualizer
 import time
 
-from pyroboplan.core.utils import get_random_collision_free_state
+from pyroboplan.core.utils import extract_cartesian_poses, get_random_collision_free_state
 from pyroboplan.models.panda import (
     load_models,
     add_self_collisions,
     add_object_collisions,
 )
+from pyroboplan.planning.path_shortcutting import shortcut_path
 from pyroboplan.planning.rrt import RRTPlanner, RRTPlannerOptions
 from pyroboplan.planning.utils import discretize_joint_space_path
+from pyroboplan.visualization.meshcat_utils import visualize_frames
 
 
 if __name__ == "__main__":
@@ -53,37 +55,22 @@ if __name__ == "__main__":
     path = planner.plan(q_start, q_end)
     planner.visualize(viz, "panda_hand", show_tree=True)
 
-    do_shortcutting = True
-    if do_shortcutting:
-        from pyroboplan.core.utils import extract_cartesian_poses
-        from pyroboplan.planning.path_shortcutting import shortcut_path
-        from pyroboplan.visualization.meshcat_utils import visualize_frames
-
-        path = shortcut_path(model, collision_model, path)
-
-        # TODO: Factor to reusable function
-        q_path = []
-        for idx in range(1, len(path)):
-            q_start = path[idx - 1]
-            q_goal = path[idx]
-            q_path = q_path + discretize_joint_space_path(
-                q_start, q_goal, options.max_angle_step
-            )
-
-        target_tforms = extract_cartesian_poses(model, "panda_hand", q_path)
-        visualize_frames(
-            viz, "shortened_path", target_tforms, line_length=0.05, line_width=1.5
-        )
-
     # Animate the path
     if path:
-        input("Press 'Enter' to animate the path.")
-        for idx in range(1, len(path)):
-            segment_start = path[idx - 1]
-            segment_end = path[idx]
-            q_path = discretize_joint_space_path(
-                segment_start, segment_end, options.max_angle_step
+        # Optionally shortcut the path
+        do_shortcutting = True
+        if do_shortcutting:
+            path = shortcut_path(model, collision_model, path)
+    
+        discretized_path =  discretize_joint_space_path(path, options.max_angle_step)
+
+        if do_shortcutting:
+            target_tforms = extract_cartesian_poses(model, "panda_hand", discretized_path)
+            visualize_frames(
+                viz, "shortened_path", target_tforms, line_length=0.05, line_width=1.5
             )
-            for q in q_path:
-                viz.display(q)
-                time.sleep(0.05)
+
+        input("Press 'Enter' to animate the path.")
+        for q in discretized_path:
+            viz.display(q)
+            time.sleep(0.05)

--- a/examples/example_rrt.py
+++ b/examples/example_rrt.py
@@ -6,7 +6,10 @@ Rapidly-Exploring Random Tree (RRT) algorithm.
 from pinocchio.visualize import MeshcatVisualizer
 import time
 
-from pyroboplan.core.utils import extract_cartesian_poses, get_random_collision_free_state
+from pyroboplan.core.utils import (
+    extract_cartesian_poses,
+    get_random_collision_free_state,
+)
 from pyroboplan.models.panda import (
     load_models,
     add_self_collisions,
@@ -61,11 +64,13 @@ if __name__ == "__main__":
         do_shortcutting = True
         if do_shortcutting:
             path = shortcut_path(model, collision_model, path)
-    
-        discretized_path =  discretize_joint_space_path(path, options.max_angle_step)
+
+        discretized_path = discretize_joint_space_path(path, options.max_angle_step)
 
         if do_shortcutting:
-            target_tforms = extract_cartesian_poses(model, "panda_hand", discretized_path)
+            target_tforms = extract_cartesian_poses(
+                model, "panda_hand", discretized_path
+            )
             visualize_frames(
                 viz, "shortened_path", target_tforms, line_length=0.05, line_width=1.5
             )

--- a/examples/example_rrt.py
+++ b/examples/example_rrt.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     # Animate the path
     if path:
         # Optionally shortcut the path
-        do_shortcutting = True
+        do_shortcutting = False
         if do_shortcutting:
             path = shortcut_path(model, collision_model, path)
 

--- a/src/pyroboplan/planning/path_shortcutting.py
+++ b/src/pyroboplan/planning/path_shortcutting.py
@@ -9,7 +9,25 @@ from pyroboplan.planning.utils import (
 
 
 def get_normalized_path_scaling(q_path):
-    """Helper function"""
+    """
+    Returns a list of length-normalized scaling values along a joint configuration path,
+    from 0.0 at the start to 1.0 at the end.
+
+    Parameters
+    ----------
+        q_path : list[array-like]
+            The list of joint configurations describing the path.
+
+    Return
+    ------
+        list[float]
+            The list of scaling values, between 0.0 and 1.0, at each of the path waypoints.
+    """
+    if len(q_path) == 0:
+        return []
+    if len(q_path) == 1:
+        return [1.0]
+
     path_length = 0.0
     path_length_list = [path_length]
     for idx in range(len(q_path) - 1):
@@ -18,29 +36,73 @@ def get_normalized_path_scaling(q_path):
     return np.array(path_length_list) / path_length
 
 
-def get_configuration_from_normalized_path_scaling(q_path, path_lengths, value):
-    """Helper function"""
+def get_configuration_from_normalized_path_scaling(q_path, path_scalings, value):
+    """
+    Given a path and its corresponding length-normalized scalings between 0.0 and 1.0,
+    get the joint configuration at a specific scale value.
+
+    For example:
+      * 0.0 will return the start configuration of the path
+      * 1.0 will return the end configuration of the path
+      * 0.5 will return the configuration halfway along the length of the path
+
+    Parameters
+    ----------
+        q_path : list[array-like]
+            The list of joint configurations describing the path.
+        path_scalings : list[float]
+            The list of scaling values, between 0.0 and 1.0, at each of the path waypoints.
+        value : float
+            The value, between 0.0 and 1.0, at which to get the joint configuration along the path.
+
+    Return
+    ------
+        tuple (array-like, int)
+            A tuple containing the joint configuration at the specified scaling value along the path,
+            as well as the index corresponding to the next point along the path.
+    """
     if value < 0 or value > 1:
         raise ValueError("Scaling value must be in the range [0, 1]")
 
-    for idx in range(len(path_lengths)):
-        if value > path_lengths[idx]:
+    for idx in range(len(path_scalings)):
+        if value > path_scalings[idx]:
             continue
 
-        delta_scale = (value - path_lengths[idx - 1]) / (
-            path_lengths[idx] - path_lengths[idx - 1]
+        delta_scale = (value - path_scalings[idx - 1]) / (
+            path_scalings[idx] - path_scalings[idx - 1]
         )
         return q_path[idx - 1] + delta_scale * (q_path[idx] - q_path[idx - 1]), idx
 
 
 def shortcut_path(
-    model, collision_model, q_path, max_iters=100, num_restarts=1, max_angle_step=0.05
+    model, collision_model, q_path, max_iters=100, num_restarts=2, max_angle_step=0.05
 ):
     """
-    Does path shortcutting wow
+    Performs path shortcutting by sampling two random points along the path and verifying
+    whether those two points can be connected directly without collisions.
 
-    Some good sources:
-      * Section 3.5.3 in https://motion.cs.illinois.edu/RoboticSystems/MotionPlanningHigherDimensions.html
+    This implementation is based on section 3.5.3 of:
+    https://motion.cs.illinois.edu/RoboticSystems/MotionPlanningHigherDimensions.html
+
+    Parameters
+    ----------
+        model : `pinocchio.Model`
+            The model of the robot.
+        collision_model : `pinocchio.Model`.
+            The model to use for collision checking.
+        q_path : list[array-like]
+            The list of joint configurations describing the path.
+        max_iters : int
+            The maximum iterations for randomly sampling shortcut points.
+        num_restarts : int
+            The number of restarts to try different random path shortcutting solutions.
+        max_angle_step : float
+            Maximum angle step, in radians, for collision checking along path segments.
+
+    Return
+    ------
+        list[array-like]
+            The shortest length path over all the shortcutting attempts.
     """
     best_path = q_path
     best_path_length = get_path_length(best_path)
@@ -49,17 +111,17 @@ def shortcut_path(
         q_shortened = copy.deepcopy(q_path)
         for _ in range(max_iters):
             # Sample two points along the path length
-            path_lengths = get_normalized_path_scaling(q_shortened)
+            path_scalings = get_normalized_path_scaling(q_shortened)
             while True:
                 low_point = np.random.random()
                 high_point = np.random.random()
                 if low_point > high_point:
                     low_point, high_point = high_point, low_point
                 q_low, idx_low = get_configuration_from_normalized_path_scaling(
-                    q_shortened, path_lengths, low_point
+                    q_shortened, path_scalings, low_point
                 )
                 q_high, idx_high = get_configuration_from_normalized_path_scaling(
-                    q_shortened, path_lengths, high_point
+                    q_shortened, path_scalings, high_point
                 )
                 if idx_low < idx_high:
                     break

--- a/src/pyroboplan/planning/path_shortcutting.py
+++ b/src/pyroboplan/planning/path_shortcutting.py
@@ -114,7 +114,7 @@ def shortcut_path(
     best_path_length = get_path_length(best_path)
 
     for _ in range(num_restarts + 1):
-        q_shortened = copy.deepcopy(q_path)
+        q_shortened = q_path
         for _ in range(max_iters):
             # If the path has been shortened to 2 points or less, this is already a shortest path.
             if len(q_shortened) < 3:
@@ -143,7 +143,7 @@ def shortcut_path(
         # Check if this is the best path so far
         shortened_path_length = get_path_length(q_shortened)
         if shortened_path_length < best_path_length:
-            best_path = copy.deepcopy(q_shortened)
+            best_path = q_shortened
             best_path_length = shortened_path_length
 
     return best_path

--- a/src/pyroboplan/planning/path_shortcutting.py
+++ b/src/pyroboplan/planning/path_shortcutting.py
@@ -1,0 +1,79 @@
+import copy
+import numpy as np
+
+from pyroboplan.core.utils import configuration_distance, get_path_length
+from pyroboplan.planning.utils import (
+    check_collisions_along_path,
+    discretize_joint_space_path,
+)
+
+
+def get_normalized_path_scaling(q_path):
+    """Helper function"""
+    path_length = 0.0
+    path_length_list = [path_length]
+    for idx in range(len(q_path) - 1):
+        path_length += configuration_distance(q_path[idx], q_path[idx + 1])
+        path_length_list.append(path_length)
+    return np.array(path_length_list) / path_length
+
+
+def get_configuration_from_normalized_path_scaling(q_path, path_lengths, value):
+    """Helper function"""
+    if value < 0 or value > 1:
+        raise ValueError("Scaling value must be in the range [0, 1]")
+
+    for idx in range(len(path_lengths)):
+        if value > path_lengths[idx]:
+            continue
+
+        delta_scale = (value - path_lengths[idx - 1]) / (
+            path_lengths[idx] - path_lengths[idx - 1]
+        )
+        return q_path[idx - 1] + delta_scale * (q_path[idx] - q_path[idx - 1]), idx
+
+
+def shortcut_path(
+    model, collision_model, q_path, max_iters=100, num_restarts=1, max_angle_step=0.05
+):
+    """
+    Does path shortcutting wow
+
+    Some good sources:
+      * Section 3.5.3 in https://motion.cs.illinois.edu/RoboticSystems/MotionPlanningHigherDimensions.html
+    """
+    best_path = q_path
+    best_path_length = get_path_length(best_path)
+
+    for _ in range(num_restarts + 1):
+        q_shortened = copy.deepcopy(q_path)
+        for _ in range(max_iters):
+            # Sample two points along the path length
+            path_lengths = get_normalized_path_scaling(q_shortened)
+            while True:
+                low_point = np.random.random()
+                high_point = np.random.random()
+                if low_point > high_point:
+                    low_point, high_point = high_point, low_point
+                q_low, idx_low = get_configuration_from_normalized_path_scaling(
+                    q_shortened, path_lengths, low_point
+                )
+                q_high, idx_high = get_configuration_from_normalized_path_scaling(
+                    q_shortened, path_lengths, high_point
+                )
+                if idx_low < idx_high:
+                    break
+
+            # Check if the points are collision free. If they are, shortcut the path.
+            path_to_goal = discretize_joint_space_path(q_low, q_high, max_angle_step)
+            if not check_collisions_along_path(model, collision_model, path_to_goal):
+                q_shortened = (
+                    q_shortened[:idx_low] + [q_low, q_high] + q_shortened[idx_high:]
+                )
+
+        # Check if this is the best path so far
+        if get_path_length(q_shortened) < best_path_length:
+            best_path = copy.deepcopy(q_shortened)
+            best_path_length = get_path_length(q_shortened)
+
+    return best_path

--- a/src/pyroboplan/planning/path_shortcutting.py
+++ b/src/pyroboplan/planning/path_shortcutting.py
@@ -65,7 +65,7 @@ def shortcut_path(
                     break
 
             # Check if the points are collision free. If they are, shortcut the path.
-            path_to_goal = discretize_joint_space_path(q_low, q_high, max_angle_step)
+            path_to_goal = discretize_joint_space_path([q_low, q_high], max_angle_step)
             if not check_collisions_along_path(model, collision_model, path_to_goal):
                 q_shortened = (
                     q_shortened[:idx_low] + [q_low, q_high] + q_shortened[idx_high:]

--- a/src/pyroboplan/planning/prm.py
+++ b/src/pyroboplan/planning/prm.py
@@ -313,9 +313,9 @@ class PRMPlanner:
         """
         if show_graph:
             path_tforms = []
-            for idx, edge in enumerate(self.graph.edges):
+            for edge in self.graph.edges:
                 q_path = discretize_joint_space_path(
-                    edge.nodeA.q, edge.nodeB.q, self.options.max_angle_step
+                    [edge.nodeA.q, edge.nodeB.q], self.options.max_angle_step
                 )
                 path_tforms.append(
                     extract_cartesian_poses(self.model, frame_name, q_path)
@@ -330,13 +330,9 @@ class PRMPlanner:
 
         visualizer.viewer[path_name].delete()
         if show_path and self.latest_path:
-            q_path = []
-            for idx in range(1, len(self.latest_path)):
-                q_start = self.latest_path[idx - 1]
-                q_goal = self.latest_path[idx]
-                q_path = q_path + discretize_joint_space_path(
-                    q_start, q_goal, self.options.max_angle_step
-                )
+            q_path = discretize_joint_space_path(
+                self.latest_path, self.options.max_angle_step
+            )
 
             target_tforms = extract_cartesian_poses(self.model, frame_name, q_path)
             visualize_frames(

--- a/src/pyroboplan/planning/rrt.py
+++ b/src/pyroboplan/planning/rrt.py
@@ -144,7 +144,7 @@ class RRTPlanner:
 
         # Check direct connection to goal.
         path_to_goal = discretize_joint_space_path(
-            q_start, q_goal, self.options.max_angle_step
+            [q_start, q_goal], self.options.max_angle_step
         )
         if not check_collisions_along_path(
             self.model, self.collision_model, path_to_goal
@@ -192,8 +192,7 @@ class RRTPlanner:
                 # If so, add it to the tree and mark planning as complete.
                 nearest_node_in_other_tree = other_tree.get_nearest_node(new_node.q)
                 path_to_other_tree = discretize_joint_space_path(
-                    new_node.q,
-                    nearest_node_in_other_tree.q,
+                    [new_node.q, nearest_node_in_other_tree.q],
                     self.options.max_angle_step,
                 )
                 if not check_collisions_along_path(
@@ -335,7 +334,7 @@ class RRTPlanner:
                 new_cost = other_node.cost + new_distance
                 if new_cost < min_cost:
                     new_path = discretize_joint_space_path(
-                        q_new, other_node.q, self.options.max_angle_step
+                        [q_new, other_node.q], self.options.max_angle_step
                     )
                     if not check_collisions_along_path(
                         self.model, self.collision_model, new_path
@@ -377,13 +376,9 @@ class RRTPlanner:
         """
         visualizer.viewer[path_name].delete()
         if show_path:
-            q_path = []
-            for idx in range(1, len(self.latest_path)):
-                q_start = self.latest_path[idx - 1]
-                q_goal = self.latest_path[idx]
-                q_path = q_path + discretize_joint_space_path(
-                    q_start, q_goal, self.options.max_angle_step
-                )
+            q_path = discretize_joint_space_path(
+                self.latest_path, self.options.max_angle_step
+            )
 
             target_tforms = extract_cartesian_poses(self.model, frame_name, q_path)
             visualize_frames(
@@ -392,9 +387,9 @@ class RRTPlanner:
 
         if show_tree:
             start_path_tforms = []
-            for idx, edge in enumerate(self.start_tree.edges):
+            for edge in self.start_tree.edges:
                 q_path = discretize_joint_space_path(
-                    edge.nodeA.q, edge.nodeB.q, self.options.max_angle_step
+                    [edge.nodeA.q, edge.nodeB.q], self.options.max_angle_step
                 )
                 start_path_tforms.append(
                     extract_cartesian_poses(self.model, frame_name, q_path)
@@ -408,9 +403,9 @@ class RRTPlanner:
             )
 
             goal_path_tforms = []
-            for idx, edge in enumerate(self.goal_tree.edges):
+            for edge in self.goal_tree.edges:
                 q_path = discretize_joint_space_path(
-                    edge.nodeA.q, edge.nodeB.q, self.options.max_angle_step
+                    [edge.nodeA.q, edge.nodeB.q], self.options.max_angle_step
                 )
                 goal_path_tforms.append(
                     extract_cartesian_poses(self.model, frame_name, q_path)

--- a/src/pyroboplan/planning/utils.py
+++ b/src/pyroboplan/planning/utils.py
@@ -72,25 +72,23 @@ def has_collision_free_path(q1, q2, max_angle_step, model, collision_model):
         return False
 
     # Ensure the discretized path is collision free.
-    path_to_q_extend = discretize_joint_space_path(q1, q2, max_angle_step)
+    path_to_q_extend = discretize_joint_space_path([q1, q2], max_angle_step)
     if check_collisions_along_path(model, collision_model, path_to_q_extend):
         return False
 
     return True
 
 
-def discretize_joint_space_path(q_start, q_end, max_angle_distance):
+def discretize_joint_space_path(q_path, max_angle_distance):
     """
-    Discretizes a joint space path from `q_start` to `q_end` given a maximum angle distance between samples.
+    Discretizes a joint space path given a maximum angle distance between samples.
 
     This is used primarily for producing paths for collision checking.
 
     Parameters
     ----------
-        q_start : array-like
-            The starting joint configuration.
-        q_end : array-like
-            The final joint configuration.
+        q_path : list[array-like]
+            A list of the joint configurations describing a path.
         max_angle_distance : float
             The maximum angular displacement, in radians, between samples.
 
@@ -99,10 +97,15 @@ def discretize_joint_space_path(q_start, q_end, max_angle_distance):
         list[array-like]
             A list of joint configuration arrays between the start and end points, inclusive.
     """
-    q_diff = q_end - q_start
-    num_steps = int(np.ceil(np.linalg.norm(q_diff) / max_angle_distance)) + 1
-    step_vec = np.linspace(0.0, 1.0, num_steps)
-    return [q_start + step * q_diff for step in step_vec]
+    q_discretized = []
+    for idx in range(1, len(q_path)):
+        q_start = q_path[idx - 1]
+        q_end = q_path[idx]
+        q_diff = q_end - q_start
+        num_steps = int(np.ceil(np.linalg.norm(q_diff) / max_angle_distance)) + 1
+        step_vec = np.linspace(0.0, 1.0, num_steps)
+        q_discretized.extend([q_start + step * q_diff for step in step_vec])
+    return q_discretized
 
 
 def retrace_path(goal_node):

--- a/src/pyroboplan/planning/utils.py
+++ b/src/pyroboplan/planning/utils.py
@@ -31,7 +31,10 @@ def extend_robot_state(q_parent, q_sample, max_connection_distance):
             The resulting robot configuration, or None if it is not feasible.
     """
     q_diff = q_sample - q_parent
-    q_increment = max_connection_distance * q_diff / np.linalg.norm(q_diff)
+    distance = np.linalg.norm(q_diff)
+    if distance == 0.0:
+        return q_sample
+    q_increment = max_connection_distance * q_diff / distance
 
     q_cur = q_parent
     # Clip the distance between nearest and sampled nodes to max connection distance.

--- a/test/planning/test_path_shortcutting.py
+++ b/test/planning/test_path_shortcutting.py
@@ -62,6 +62,21 @@ def test_get_configuration_from_normalized_path_scaling():
     assert idx == 2
 
 
+def test_path_shortcutting_noop():
+    model, collision_model, _ = load_models()
+    add_self_collisions(model, collision_model)
+
+    # Define a multi-configuration path
+    q_path = [
+        np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+        np.array([0.785, 1.57, 0.0, 0.0, 1.57, 1.57, 0.0, 0.0, -0.785]),
+    ]
+
+    # Check that the shortened path is the same as the original path.
+    q_shortened = shortcut_path(model, collision_model, q_path)
+    assert q_shortened == q_path
+
+
 def test_path_shortcutting():
     model, collision_model, _ = load_models()
     add_self_collisions(model, collision_model)

--- a/test/planning/test_path_shortcutting.py
+++ b/test/planning/test_path_shortcutting.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+from pyroboplan.core.utils import get_path_length
+from pyroboplan.models.panda import load_models, add_self_collisions
+from pyroboplan.planning.path_shortcutting import shortcut_path
+
+
+def test_path_shortcutting():
+    model, collision_model, _ = load_models()
+    add_self_collisions(model, collision_model)
+
+    # Define a multi-configuration path
+    q_path = [
+        np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+        np.array([0.00, 1.57, 0.0, 0.0, 1.57, 1.57, 0.0, 0.0, 0.0]),
+        np.array([0.785, 1.57, 0.0, 0.0, 1.57, 1.57, 0.0, 0.0, 0.0]),
+        np.array([0.785, 1.57, 0.0, 0.0, 1.57, 1.57, 0.0, 0.0, -0.785]),
+    ]
+
+    q_shortened = shortcut_path(model, collision_model, q_path)
+    print(
+        f"Path shortened from {get_path_length(q_path)} to {get_path_length(q_shortened)}"
+    )
+    print(f"Direct path length = {get_path_length([q_path[0], q_path[-1]])}")
+    # Check that the shortened path is shorter than original, but cannot be shorter than a direct path from start to end.
+    assert get_path_length(q_shortened) <= get_path_length(q_path)
+    assert get_path_length(q_shortened) >= get_path_length([q_path[0], q_path[-1]])
+
+
+if __name__ == "__main__":
+    test_path_shortcutting()

--- a/test/planning/test_path_shortcutting.py
+++ b/test/planning/test_path_shortcutting.py
@@ -1,8 +1,65 @@
 import numpy as np
+import pytest
 
 from pyroboplan.core.utils import get_path_length
 from pyroboplan.models.panda import load_models, add_self_collisions
-from pyroboplan.planning.path_shortcutting import shortcut_path
+from pyroboplan.planning.path_shortcutting import (
+    get_normalized_path_scaling,
+    get_configuration_from_normalized_path_scaling,
+    shortcut_path,
+)
+
+
+def test_get_normalized_path_scaling():
+    # Trivial empty path case
+    assert get_normalized_path_scaling([]) == []
+
+    # Trivial single-element path case
+    assert get_normalized_path_scaling([np.array([1.0, 2.0, 3.0])]) == [1.0]
+
+    # Nontrivial and realistic case with a multi-waypoint path
+    scaling = get_normalized_path_scaling(
+        [
+            np.array([0.0, 0.0, 0.0]),
+            np.array([1.0, 0.0, 0.0]),
+            np.array([1.0, 2.0, 0.0]),
+            np.array([1.0, 2.0, -1.0]),
+        ]
+    )
+    assert scaling == pytest.approx([0.0, 0.25, 0.75, 1.0])
+
+
+def test_get_configuration_from_normalized_path_scaling():
+    path = [
+        np.array([0.0, 0.0, 0.0]),
+        np.array([1.0, 0.0, 0.0]),
+        np.array([1.0, 2.0, 0.0]),
+        np.array([1.0, 2.0, -1.0]),
+    ]
+    scaling = get_normalized_path_scaling(path)
+
+    # Invalid values
+    with pytest.raises(ValueError):
+        get_configuration_from_normalized_path_scaling(path, scaling, -1.0)
+        get_configuration_from_normalized_path_scaling(path, scaling, 2.0)
+
+    # Start and end of the path
+    q, idx = get_configuration_from_normalized_path_scaling(path, scaling, 0.0)
+    assert q == pytest.approx(path[0])
+    assert idx == 0
+
+    q, idx = get_configuration_from_normalized_path_scaling(path, scaling, 1.0)
+    assert q == pytest.approx(path[-1])
+    assert idx == len(path) - 1
+
+    # Points along the path
+    q, idx = get_configuration_from_normalized_path_scaling(path, scaling, 0.25)
+    assert q == pytest.approx(path[1])
+    assert idx == 1
+
+    q, idx = get_configuration_from_normalized_path_scaling(path, scaling, 0.5)
+    assert q == pytest.approx(0.5 * (path[1] + path[2]))
+    assert idx == 2
 
 
 def test_path_shortcutting():
@@ -17,15 +74,7 @@ def test_path_shortcutting():
         np.array([0.785, 1.57, 0.0, 0.0, 1.57, 1.57, 0.0, 0.0, -0.785]),
     ]
 
-    q_shortened = shortcut_path(model, collision_model, q_path)
-    print(
-        f"Path shortened from {get_path_length(q_path)} to {get_path_length(q_shortened)}"
-    )
-    print(f"Direct path length = {get_path_length([q_path[0], q_path[-1]])}")
     # Check that the shortened path is shorter than original, but cannot be shorter than a direct path from start to end.
+    q_shortened = shortcut_path(model, collision_model, q_path)
     assert get_path_length(q_shortened) <= get_path_length(q_path)
     assert get_path_length(q_shortened) >= get_path_length([q_path[0], q_path[-1]])
-
-
-if __name__ == "__main__":
-    test_path_shortcutting()

--- a/test/planning/test_planning_utils.py
+++ b/test/planning/test_planning_utils.py
@@ -29,12 +29,12 @@ def test_discretize_joint_space_path():
     max_angle_distance = 1.0
 
     # Starting from the same point should just return the point.
-    path = discretize_joint_space_path(q_start, q_start, max_angle_distance)
+    path = discretize_joint_space_path([q_start, q_start], max_angle_distance)
     assert len(path) == 1
     assert np.array_equal(path, [q_start])
 
     # Discretize at 0.5 radians and verify the expected result.
-    path = discretize_joint_space_path(q_start, q_end, max_angle_distance)
+    path = discretize_joint_space_path([q_start, q_end], max_angle_distance)
     expected_path = [
         np.array([0.0, 0.0]),
         np.array([1.0, 0.0]),


### PR DESCRIPTION
This implements the path shortcutting method described in section 3.5.3 of https://motion.cs.illinois.edu/RoboticSystems/MotionPlanningHigherDimensions.html

It also adds the shortcutting to the PRM and RRT examples. In doing so, I generalized the interface to the `discretize_joint_space_path` function which simplified a  bunch of redundant code.

https://github.com/sea-bass/pyroboplan/assets/4603398/afebe5cb-e97e-4b0e-a757-ae0fdb61917c

Closes https://github.com/sea-bass/pyroboplan/issues/39