### PR TITLE
Remove .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.gif filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
I'm getting billing emails that the whopping two (2) GIFs I had set up with LFS are about to max out my free-tier bandwidth.

So now you're all forced to download those extra few MB.