### PR TITLE
First implementation of informed rrt star

### DIFF
--- a/examples/example_informed_rrt.py
+++ b/examples/example_informed_rrt.py
@@ -1,0 +1,84 @@
+"""
+This example shows PyRoboPlan capabilities for path planning using
+Informed Rapidly-Exploring Random Tree (Informed RRT) algorithm.
+"""
+
+from pinocchio.visualize import MeshcatVisualizer
+import numpy as np
+import time
+
+from pyroboplan.core.utils import (
+    extract_cartesian_poses,
+    get_random_collision_free_state,
+)
+from pyroboplan.models.panda import (
+    load_models,
+    add_self_collisions,
+    add_object_collisions,
+)
+from pyroboplan.planning.path_shortcutting import shortcut_path
+from pyroboplan.planning.rrt import RRTPlanner, RRTPlannerOptions
+from pyroboplan.planning.utils import discretize_joint_space_path
+from pyroboplan.visualization.meshcat_utils import visualize_frames
+
+
+if __name__ == "__main__":
+    # Create models and data
+    model, collision_model, visual_model = load_models()
+    add_self_collisions(model, collision_model)
+    add_object_collisions(model, collision_model, visual_model)
+
+    data = model.createData()
+    collision_data = collision_model.createData()
+
+    # Initialize visualizer
+    viz = MeshcatVisualizer(model, collision_model, visual_model, data=data)
+    viz.initViewer(open=True)
+    viz.loadViewerModel()
+
+    # Define the start and end configurations
+    q_start = get_random_collision_free_state(model, collision_model)
+    q_end = get_random_collision_free_state(model, collision_model)
+    viz.display(q_start)
+    time.sleep(1.0)
+
+    # Search for a path
+    options = RRTPlannerOptions(
+        max_step_size=0.05,
+        max_connection_dist=np.inf,
+        rrt_connect=False,
+        bidirectional_rrt=False,
+        rrt_star=False,
+        informed_rrt_star=True,
+        max_rewire_dist=np.inf,
+        max_planning_time=45,
+        fast_return=False,
+        goal_biasing_probability=0.15,
+        visual_model=viz,
+    )
+
+    planner = RRTPlanner(model, collision_model, options=options)
+    path = planner.plan(q_start, q_end)
+    planner.visualize(viz, "panda_hand", show_tree=True)
+
+    # Animate the path
+    if path:
+        # Optionally shortcut the path
+        do_shortcutting = False
+        if do_shortcutting:
+            path = shortcut_path(model, collision_model, path)
+
+        discretized_path = discretize_joint_space_path(path, options.max_step_size)
+
+        if do_shortcutting:
+            target_tforms = extract_cartesian_poses(
+                model, "panda_hand", discretized_path
+            )
+            visualize_frames(
+                viz, "shortened_path", target_tforms, line_length=0.05, line_width=1.5
+            )
+
+        input("Press 'Enter' to animate the path.")
+        for q in discretized_path:
+            viz.display(q)
+            time.sleep(0.05)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "matplotlib == 3.8.4",
   "meshcat == 0.3.2",
   "scipy == 1.13.0",
+  "trimesh == 4.4.0",
 ]
 requires-python = ">=3.8"
 authors = [

--- a/src/pyroboplan/models/utils.py
+++ b/src/pyroboplan/models/utils.py
@@ -1,7 +1,11 @@
-""" Utilities for model loading. """
+""" Utilities for model generation and loading. """
 
 import importlib.resources
 import pyroboplan
+import pinocchio
+import trimesh
+import hppfcl
+import numpy as np
 
 
 def get_example_models_folder():
@@ -15,3 +19,74 @@ def get_example_models_folder():
     """
     resource_path = importlib.resources.files(pyroboplan) / "models"
     return resource_path.as_posix()
+
+
+def create_ellipsoid_mesh(radius_x, radius_y, radius_z, subdivisions=3):
+    """
+    Creates an ellipsoid mesh with the given radii and subdivisions.
+
+    Parameters
+    ----------
+        radius_x : float
+            The x-axis radius of the ellipsoid.
+        radius_y : float
+            The y-axis radius of the ellipsoid.
+        radius_z : float
+            The z-axis radius of the ellipsoid.
+        subdivisions : int, optional
+            The number of subdivisions to use when creating the sphere mesh.
+        
+    Returns
+    -------
+        hppfcl.BVHModelOBB
+            The mesh of the ellipsoid.
+    """
+    sphere = trimesh.creation.icosphere(subdivisions=subdivisions, radius=1.0)
+    ellipsoid = sphere.copy()
+    ellipsoid.apply_scale([radius_x, radius_y, radius_z])
+    vertices = ellipsoid.vertices.astype(np.float32)
+    faces = ellipsoid.faces.astype(np.int32)
+    fcl_mesh = hppfcl.BVHModelOBB()
+    fcl_mesh.beginModel(vertices.shape[0], faces.shape[0])
+    for vertex in vertices:
+        fcl_mesh.addVertex(np.array(vertex, dtype=np.float64))
+    for face in faces:
+        fcl_mesh.addTriangle(
+            np.array(vertices[face[0]], dtype=np.float64),
+            np.array(vertices[face[1]], dtype=np.float64),
+            np.array(vertices[face[2]], dtype=np.float64)
+        )
+    fcl_mesh.endModel()
+    return fcl_mesh
+
+
+def add_ellipsoid_model(model, ellipsoid_mesh, position, rotation_matrix, name='ellipsoid', color=np.array([0.5, 0.5, 0.5, 0.5])):
+    """
+    Add an ellipsoid to the given model at the specified position and rotation.
+
+    Parameters
+    ----------
+        model : `pinocchio.Model`
+            The model from which to generate a random state.
+        ellipsoid_mesh : hppfcl.BVHModelOBB
+            The mesh of the ellipsoid to add.
+        position : list
+            The position of the center of the ellipsoid.
+        rotation_matrix : list[array-like]
+            The rotation matrix of the ellipsoid.
+        name : str, optional
+            The name of the ellipsoid to add.
+        color : list, optional
+            The color of the ellipsoid to add.
+    """
+    position = np.array(position)
+    ellipsoid = pinocchio.GeometryObject(
+        name,
+        0,
+        ellipsoid_mesh,
+        pinocchio.SE3(rotation_matrix, position)
+    )
+    ellipsoid.meshColor = color
+    model.addGeometryObject(ellipsoid)
+    ellipsoid.collision_model = None
+    model.display()


### PR DESCRIPTION
This informed rrt star implementation focuses on the sampling portion, and starts after a route to the goal is found using rrt star. The start and goal configurations of the robot's end effector are transformed to their Cartesian coordinates and an ellipsoid is formed to only sample configurations inside of that 3d space. Inverse kinematics is used to transform a sampled pose to the joint configurations of the robot. Visualization of the ellipsoid where the sampling occurs is also a part of this.

There are some known issues to work on still: 

1. Unit tests need to be developed for informed rrt star and need to verify no existing test now fails.
2. Still need to do some formatting passes.
3. Since the panda moves in joint configuration and not cartesian configuration, there are collisions being generated (may also be due to not verifying for collision during IK).
4. In some start and goal configurations, the ellipsoid can flatten and become almost two dimensional.
5. Points sampled in the ellipsoid will not lead to a better path if the robot needs to turn from the longer direction to reach the goal configuration.


Attached is a screenshot of an ideal random test case (where the ellipsoid has the color gray and no collision model):
![Ideal informed rrt star run example](https://github.com/sea-bass/pyroboplan/assets/29734044/7218ffd8-2c75-4691-a363-786d91b9d86c)
