### PR TITLE
Add RNG seed option to PRM, RRT, and IK solver options

### DIFF
--- a/examples/example_cartesian_path.py
+++ b/examples/example_cartesian_path.py
@@ -55,7 +55,7 @@ ik = DifferentialIk(
     model,
     data=data,
     collision_model=collision_model,
-    options=DifferentialIkOptions(max_retries=5),
+    options=DifferentialIkOptions(max_retries=5, rng_seed=None),
 )
 
 # Create the Cartesian Planner over the entire desired path.

--- a/examples/example_differential_ik.py
+++ b/examples/example_differential_ik.py
@@ -50,6 +50,7 @@ if __name__ == "__main__":
         min_step_size=0.025,
         max_step_size=0.1,
         ignore_joint_indices=ignore_joint_indices,
+        rng_seed=None,
     )
     ik = DifferentialIk(
         model,

--- a/examples/example_prm.py
+++ b/examples/example_prm.py
@@ -112,6 +112,7 @@ if __name__ == "__main__":
         max_neighbor_connections=10,
         max_construction_nodes=2500,
         construction_timeout=20.0,
+        rng_seed=None,
         prm_star=False,
         prm_file=prm_file if load_prm else None,
     )

--- a/examples/example_rrt.py
+++ b/examples/example_rrt.py
@@ -50,6 +50,7 @@ if __name__ == "__main__":
         rrt_star=False,
         max_rewire_dist=3.0,
         max_planning_time=10.0,
+        rng_seed=None,
         fast_return=True,
         goal_biasing_probability=0.15,
     )

--- a/src/pyroboplan/ik/differential_ik.py
+++ b/src/pyroboplan/ik/differential_ik.py
@@ -29,6 +29,7 @@ class DifferentialIkOptions:
         min_step_size=0.1,
         max_step_size=0.5,
         ignore_joint_indices=[],
+        rng_seed=None,
     ):
         """
         Initializes a set of differential IK options.
@@ -56,6 +57,8 @@ class DifferentialIkOptions:
             ignore_joint_indices : list[int], optional
                 A list of joints to ignore changing when solving IK.
                 TODO: This should eventually be done through a concept of joint groups.
+            rng_seed : int, optional
+                Sets the seed for random number generation. Use to generate deterministic results.
         """
         self.max_iters = max_iters
         self.max_retries = max_retries
@@ -65,10 +68,12 @@ class DifferentialIkOptions:
         self.min_step_size = min_step_size
         self.max_step_size = max_step_size
         self.ignore_joint_indices = ignore_joint_indices
+        self.rng_seed = rng_seed
 
 
 class DifferentialIk:
-    """Differential IK solver.
+    """
+    Differential IK solver.
 
     This is a numerical IK solver that uses the manipulator's Jacobian to take first-order steps towards a solution.
     It contains several of the common options such as damped least squares (Levenberg-Marquardt), random restarts, and nullspace projection.
@@ -149,6 +154,7 @@ class DifferentialIk:
             array-like or None
                 A list of joint configuration values with the solution, if one was found. Otherwise, returns None.
         """
+        np.random.seed(self.options.rng_seed)
         target_frame_id = self.model.getFrameId(target_frame)
 
         # Create a random initial state, if not specified

--- a/src/pyroboplan/planning/prm.py
+++ b/src/pyroboplan/planning/prm.py
@@ -31,6 +31,7 @@ class PRMPlannerOptions:
         max_neighbor_connections=15,
         max_construction_nodes=5000,
         construction_timeout=10.0,
+        rng_seed=None,
         prm_star=False,
         prm_file=None,
     ):
@@ -49,6 +50,8 @@ class PRMPlannerOptions:
                 The maximum number of samples to generate in the configuration space when growing the graph.
             construction_timeout : float
                 Maximum time allotted to sample the configuration space per call.
+            rng_seed : int, optional
+                Sets the seed for random number generation. Use to generate deterministic results.
             prm_star : str
                 If True, use the PRM* approach to dynamically select the radius and max number of neighbors
                 during construction of the roadmap.
@@ -59,6 +62,7 @@ class PRMPlannerOptions:
         self.max_step_size = max_step_size
         self.max_neighbor_radius = max_neighbor_radius
         self.max_neighbor_connections = max_neighbor_connections
+        self.rng_seed = rng_seed
         self.construction_timeout = construction_timeout
         self.max_construction_nodes = max_construction_nodes
         self.prm_star = prm_star
@@ -120,6 +124,7 @@ class PRMPlanner:
                 Defaults to randomly sampling the robot's configuration space.
         """
         # Default to randomly sampling the model if no sample function is provided.
+        np.random.seed(self.options.rng_seed)
         if not sample_generator:
             sample_generator = random_model_state_generator(self.model)
 

--- a/src/pyroboplan/planning/rrt.py
+++ b/src/pyroboplan/planning/rrt.py
@@ -33,6 +33,7 @@ class RRTPlannerOptions:
         rrt_star=False,
         max_rewire_dist=np.inf,
         max_planning_time=10.0,
+        rng_seed=None,
         fast_return=True,
         goal_biasing_probability=0.0,
     ):
@@ -59,6 +60,8 @@ class RRTPlannerOptions:
                 If set to `np.inf`, all nodes in the trees will be considered for rewiring.
             max_planning_time : float
                 Maximum planning time, in seconds.
+            rng_seed : int, optional
+                Sets the seed for random number generation. Use to generate deterministic results.
             fast_return : bool
                 If True, return as soon as a solution is found. Otherwise continuing building the tree
                 until max_planning_time is reached.
@@ -72,6 +75,7 @@ class RRTPlannerOptions:
         self.rrt_star = rrt_star
         self.max_rewire_dist = max_rewire_dist
         self.max_planning_time = max_planning_time
+        self.rng_seed = rng_seed
         self.fast_return = fast_return
         self.goal_biasing_probability = goal_biasing_probability
 
@@ -112,6 +116,7 @@ class RRTPlanner:
         self.latest_path = None
         self.start_tree = Graph()
         self.goal_tree = Graph()
+        np.random.seed(self.options.rng_seed)
 
     def plan(self, q_start, q_goal):
         """

--- a/test/planning/test_prm.py
+++ b/test/planning/test_prm.py
@@ -6,10 +6,6 @@ from pyroboplan.models.two_dof import (
 from pyroboplan.planning.prm import PRMPlanner, PRMPlannerOptions
 
 
-# Use a fixed seed for random number generation in tests.
-np.random.seed(1234)
-
-
 def construct_roadmap_test(options):
     # Initialize models, and construct and return a planner with the provided options
     model, collision_model, _ = load_models()
@@ -63,6 +59,7 @@ def test_prm():
         max_neighbor_connections=5,
         max_construction_nodes=2500,
         construction_timeout=1.0,
+        rng_seed=1234,
         prm_file=None,
     )
 

--- a/test/planning/test_rrt.py
+++ b/test/planning/test_rrt.py
@@ -9,10 +9,6 @@ from pyroboplan.models.panda import (
 from pyroboplan.planning.rrt import RRTPlanner, RRTPlannerOptions
 
 
-# Use a fixed seed for random number generation in tests.
-np.random.seed(1234)
-
-
 def test_plan_trivial_rrt():
     model, collision_model, _ = load_models()
 
@@ -67,6 +63,7 @@ def test_plan_rrt_connect():
     options = RRTPlannerOptions(
         rrt_connect=True,
         bidirectional_rrt=True,
+        rng_seed=1234,
     )
     planner = RRTPlanner(model, collision_model, options=options)
     path = planner.plan(q_start, q_goal)
@@ -93,7 +90,8 @@ def test_plan_rrt_star():
     q_goal = np.array([1.57, 1.57, 0.0, 0.0, 1.57, 1.57, 0.0, 0.0, 0.0])
 
     # First, plan with regular RRT.
-    options = RRTPlannerOptions()
+    np.random.seed(1234)
+    options = RRTPlannerOptions(rng_seed=1234)
     options.rrt_star = False
     options.bidirectional_rrt = True
     planner = RRTPlanner(model, collision_model, options=options)
@@ -101,7 +99,6 @@ def test_plan_rrt_star():
 
     # Then, plan with RRT* enabled (use maximum rewire distance for effect).
     # Note we need to reset the seed so the nominal plans are equivalent.
-    np.random.seed(1234)
     options.rrt_star = True
     options.max_rewire_dist = np.inf
     planner = RRTPlanner(model, collision_model, options=options)


### PR DESCRIPTION
Getting some recent nondeterminism in the RRT tests nightly runs, so throwing seeds at the problem!

(anyways this stuff is good to have)

NOTE I considered using the new [NumPy Random Generators](https://numpy.org/doc/stable/reference/random/generator.html), but found it a bit awkward for here since you would need to modify all the functions like `get_random_state()`, `get_random_collision_free_state()`, etc. to accept RNG objects and/or seeds as inputs.