### PR TITLE
add a point robot example

### DIFF
--- a/docs/source/api/pyroboplan.models.rst
+++ b/docs/source/api/pyroboplan.models.rst
@@ -9,6 +9,14 @@ pyroboplan.models package
 Submodules
 ----------
 
+pyroboplan.models.marble module
+-------------------------------
+
+.. automodule:: pyroboplan.models.marble
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 pyroboplan.models.panda module
 ------------------------------
 

--- a/examples/rrt_marble.py
+++ b/examples/rrt_marble.py
@@ -1,0 +1,89 @@
+"""
+RRT path planning example with a point robot in a 2D planar labyrinth.
+"""
+
+from pinocchio.visualize import MeshcatVisualizer
+import time
+
+from pyroboplan.core.utils import (
+    get_random_collision_free_state,
+    extract_cartesian_poses,
+)
+from pyroboplan.models.marble import load_models, add_object_collisions
+from pyroboplan.planning.rrt import RRTPlanner, RRTPlannerOptions
+from pyroboplan.planning.utils import discretize_joint_space_path
+from pyroboplan.planning.path_shortcutting import shortcut_path
+from pyroboplan.visualization.meshcat_utils import visualize_frames
+
+if __name__ == "__main__":
+    # Create models and data
+    model, collision_model, visual_model = load_models()
+    add_object_collisions(model, collision_model, visual_model)
+    data = model.createData()
+    collision_data = collision_model.createData()
+
+    # Initialize visualizer
+    viz = MeshcatVisualizer(model, collision_model, visual_model, data=data)
+    viz.initViewer(open=False)
+    viz.loadViewerModel()
+    # optional pseudo orthographic view
+    # viz.viewer["/Cameras/default/rotated/<object>"].set_property("zoom", 10)
+
+    # Define the start and end configurations
+    q_start = get_random_collision_free_state(
+        model, collision_model, distance_padding=0.1
+    )
+    q_end = get_random_collision_free_state(
+        model, collision_model, distance_padding=0.1
+    )
+
+    # Configure the RRT planner
+    options = RRTPlannerOptions(
+        max_step_size=0.02,
+        max_connection_dist=2.0,
+        rrt_connect=True,
+        bidirectional_rrt=True,
+        rrt_star=False,
+        max_rewire_dist=1.0,
+        max_planning_time=1.0,
+        rng_seed=None,
+        fast_return=True,
+        goal_biasing_probability=0.1,
+        collision_distance_padding=0.0,
+    )
+
+    planner = RRTPlanner(model, collision_model, options=options)
+
+    while True:
+        viz.display(q_start)
+
+        path = planner.plan(q_start, q_end)
+        planner.visualize(viz, "body", show_tree=True, show_path=False)
+        if path:
+            do_shortcutting = True
+            if do_shortcutting:
+                path = shortcut_path(
+                    model,
+                    collision_model,
+                    path,
+                    max_iters=200,
+                    max_step_size=options.max_step_size,
+                )
+            path = discretize_joint_space_path(path, options.max_step_size)
+            target_tforms = extract_cartesian_poses(model, "body", path)
+            viz.viewer["shortened_path"].delete()
+            visualize_frames(
+                viz,
+                "shortened_path",
+                target_tforms,
+                line_length=0.05,
+                line_width=2.5,
+            )
+
+            for q in path:
+                viz.display(q)
+                time.sleep(0.01)
+
+            input("Press 'Enter' to plan another path, or ctrl-c to quit.")
+            q_start = q_end
+        q_end = get_random_collision_free_state(model, collision_model)

--- a/src/pyroboplan/models/marble.py
+++ b/src/pyroboplan/models/marble.py
@@ -1,0 +1,78 @@
+"""Utilities to load a 2d spherical body resembling a marble labyrinth."""
+
+import coal
+import numpy as np
+import os
+import pinocchio
+
+from ..core.utils import set_collisions
+from .utils import get_example_models_folder
+
+
+def load_models():
+    """
+    Gets the example 2-DOF models.
+
+    Returns
+    -------
+        tuple[`pinocchio.Model`]
+            A 3-tuple containing the model, collision geometry model, and visual geometry model.
+    """
+    models_folder = get_example_models_folder()
+    package_dir = os.path.join(models_folder, "marble_description")
+    urdf_filename = os.path.join(package_dir, "marble.urdf")
+
+    return pinocchio.buildModelsFromUrdf(urdf_filename, package_dirs=models_folder)
+
+
+def add_object_collisions(model, collision_model, visual_model):
+    ground_plane = pinocchio.GeometryObject(
+        "ground",
+        0,
+        pinocchio.SE3(np.eye(3), np.array([1.0, 0.5, -0.05 - 0.02])),
+        coal.Box(2.1, 1.1, 0.1),
+    )
+    ground_plane.meshColor = np.array([0.8, 0.8, 0.8, 1.0])
+    visual_model.addGeometryObject(ground_plane)
+    collision_model.addGeometryObject(ground_plane)
+
+    box_idx = 0
+
+    def box_on_plane(x, y, w, h):
+        nonlocal box_idx
+        box_idx += 1
+        box = pinocchio.GeometryObject(
+            f"box{box_idx}",
+            0,
+            pinocchio.SE3(np.eye(3), np.array([x + w / 2, y + h / 2, 0.0])),
+            coal.Box(w, h, 0.04),
+        )
+        box.meshColor = np.array([0.3, 0.3, 0.3, 1.0])
+        visual_model.addGeometryObject(box)
+        collision_model.addGeometryObject(box)
+
+    # outer walls
+    box_on_plane(-0.05, -0.05, 0.05, 1.1)
+    box_on_plane(2.0, -0.05, 0.05, 1.1)
+    box_on_plane(-0.05, -0.05, 2.1, 0.05)
+    box_on_plane(-0.05, 1.0, 2.1, 0.05)
+
+    # obstacles
+    box_on_plane(0.3, 0.0, 0.05, 0.7)
+    box_on_plane(0.75, 0.2, 0.05, 0.8)
+    box_on_plane(1.3, 0.0, 0.05, 0.3)
+    box_on_plane(0.8, 0.5, 0.5, 0.05)
+    box_on_plane(1.6, 0.45, 0.05, 0.4)
+    box_on_plane(1.65, 0.45, 0.35, 0.05)
+
+    # split workspace so that many plans will not be feasible and the search trees fill the plane
+    # box_on_plane(1.0, 0.0, 0.05, 0.5)
+
+    # Define the active collision pairs between the robot and obstacle links.
+    obstacle_names = [
+        cobj.name
+        for cobj in collision_model.geometryObjects
+        if cobj.name.startswith("box")
+    ]
+    for obstacle_name in obstacle_names:
+        set_collisions(model, collision_model, obstacle_name, "body", True)

--- a/src/pyroboplan/models/marble_description/marble.urdf
+++ b/src/pyroboplan/models/marble_description/marble.urdf
@@ -1,0 +1,36 @@
+<!-- Simple point robot moving in a plane -->
+<robot name="two_dof_robot">
+    <link name="base"/>
+
+    <link name="body">
+        <visual>
+            <geometry>
+                <sphere radius="0.02" />
+            </geometry>
+            <origin rpy="0 0 0" xyz="0 0 0"/>
+            <material name="green">
+                <color rgba="0 1.0 0 1.0"/>
+            </material>
+        </visual>
+        <collision>
+            <geometry>
+                <sphere radius="0.02" />
+            </geometry>
+            <origin rpy="0 0 0" xyz="0 0 0"/>
+        </collision>
+    </link>
+
+    <link name="x_axis" />
+    <joint name="x" type="prismatic">
+        <axis rpy="0 0 0" xyz="1 0 0"/>
+        <parent link="base"/>
+        <child link="x_axis"/>
+        <limit lower="0" upper="2" velocity="1.0" effort="1000" />
+    </joint>
+    <joint name="y" type="prismatic">
+        <axis rpy="0 0 0" xyz="0 1 0"/>
+        <parent link="x_axis"/>
+        <child link="body"/>
+        <limit lower="0" upper="1" velocity="1.0" effort="1000" />
+    </joint>
+</robot>


### PR DESCRIPTION
2d point robots are quite traditional to illustrate planner behavior and I needed the example illustration anyway. I think it would make sense to provide it in pyroboplan.
I had trouble finding a good and adjustable 2d point robot visualization of RRT-Connect, so I wrote this one.

By code it is very similar to the 2dof (revolute joints) and panda examples.

![marble](https://github.com/user-attachments/assets/18e34439-2e14-4853-acb5-2195a6d964f9)
