### PR TITLE
clear old frames when prefix is used again

### DIFF
--- a/examples/rrt_marble.py
+++ b/examples/rrt_marble.py
@@ -71,7 +71,6 @@ if __name__ == "__main__":
                 )
             path = discretize_joint_space_path(path, options.max_step_size)
             target_tforms = extract_cartesian_poses(model, "body", path)
-            viz.viewer["shortened_path"].delete()
             visualize_frames(
                 viz,
                 "shortened_path",

--- a/src/pyroboplan/visualization/meshcat_utils.py
+++ b/src/pyroboplan/visualization/meshcat_utils.py
@@ -78,6 +78,7 @@ def visualize_frames(
         line_color : array-like, optional
             The line colors to use. If None, chooses default axes colors.
     """
+    visualizer.viewer[prefix_name].delete()
     for idx, tform in enumerate(tforms):
         visualize_frame(
             visualizer,


### PR DESCRIPTION
In https://github.com/sea-bass/pyroboplan/pull/83/commits/a2fec8cb21cd5309e0a7c305c5b78a074af0815b you removed my explicit `delete` again which is necessary to avoid dangling frames from previous attempts.

This patch suggests to fix this more appropriately on the library level.

![screenshot250204-174104](https://github.com/user-attachments/assets/3aa96964-4ec2-4467-b9b5-cc6ccff6ed1d)
