### PR TITLE
Add nodes at each connection step of RRT-Connect

### DIFF
--- a/test/planning/test_rrt.py
+++ b/test/planning/test_rrt.py
@@ -63,6 +63,7 @@ def test_plan_rrt_connect():
     options = RRTPlannerOptions(
         rrt_connect=True,
         bidirectional_rrt=True,
+        max_connection_dist=0.75,
         rng_seed=1234,
     )
     planner = RRTPlanner(model, collision_model, options=options)


### PR DESCRIPTION
By recently looking at @adlarkin 's RRT implementation, I noticed that my RRT-Connect was not quite correct in that I wasn't adding any intermediate nodes during a long `CONNECT` step -- I was only adding the final one, which I think is not correct.