### PR TITLE
Use TOPP-RA version on PyPi

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "external/toppra"]
-	path = external/toppra
-	url = https://github.com/CoMMALab/toppra.git

--- a/README.md
+++ b/README.md
@@ -45,25 +45,3 @@ Install this package and its dependencies.
 ```bash
 pip3 install -e .
 ```
-
-## External dependencies
-
-We are using [Git submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) to manage external dependencies that must be included from source.
-
-To set up this repo's submodules, the following step is required.
-
-```bash
-git submodule init
-git submodule update
-```
-
-### TOPP-RA
-
-To use the [TOPP-RA](https://github.com/CoMMALab/toppra/tree/develop) repository for trajectory timing, you must install it as follows.
-
-```bash
-cd external/toppra
-pip3 install -e .
-```
-
-The `examples/cartesian_path.py` script currently uses TOPP-RA as an option.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,12 @@ build-backend = "hatchling.build"
 name = "pyroboplan"
 version = "1.1.0"
 dependencies = [
-  "drake == 1.38.0",
+  "drake == 1.39.0",
   "pin == 3.4.0",
   "matplotlib == 3.10.1",
   "meshcat == 0.3.2",
   "scipy == 1.15.2",
+  "toppra == 0.6.3",
 ]
 requires-python = ">=3.10"
 authors = [


### PR DESCRIPTION
The NumPy >= 2.0 fix for TOPP-RA was merged, so good bye submodules!