### PR TITLE
Fix path shortcutting logic

### DIFF
--- a/src/pyroboplan/planning/path_shortcutting.py
+++ b/src/pyroboplan/planning/path_shortcutting.py
@@ -106,11 +106,12 @@ def shortcut_path(model, collision_model, q_path, max_iters=100, max_step_size=0
         return q_path
 
     q_shortened = q_path
+    path_changed = True
     for _ in range(max_iters):
         if len(q_shortened) < 3:
             # If the path has been shortened to 2 points or less, this is already a shortest path.
             break
-        elif len(q_shortened) == 3:
+        elif path_changed and (len(q_shortened) == 3):
             # If the path has exactly 3 points, try to remove the middle point and return the path.
             path_to_goal = discretize_joint_space_path(
                 [q_shortened[0], q_shortened[2]], max_step_size
@@ -120,6 +121,7 @@ def shortcut_path(model, collision_model, q_path, max_iters=100, max_step_size=0
                 break
 
         # Sample two points along the path length
+        path_changed = False
         path_scalings = get_normalized_path_scaling(q_shortened)
 
         low_point, high_point = sorted(np.random.random(2))
@@ -139,4 +141,5 @@ def shortcut_path(model, collision_model, q_path, max_iters=100, max_step_size=0
             q_shortened[idx_low] = q_low
             q_shortened[idx_high - 1] = q_high
             q_shortened = q_shortened[:idx_low] + q_shortened[idx_high - 1 :]
+            path_changed = True
     return q_shortened

--- a/src/pyroboplan/planning/path_shortcutting.py
+++ b/src/pyroboplan/planning/path_shortcutting.py
@@ -111,13 +111,13 @@ def shortcut_path(model, collision_model, q_path, max_iters=100, max_step_size=0
             # If the path has been shortened to 2 points or less, this is already a shortest path.
             break
         elif len(q_shortened) == 3:
-            # If the path has exactly 3 points, try to remove the middle point and return regardless.
+            # If the path has exactly 3 points, try to remove the middle point and return the path.
             path_to_goal = discretize_joint_space_path(
                 [q_shortened[0], q_shortened[2]], max_step_size
             )
             if not (check_collisions_along_path(model, collision_model, path_to_goal)):
                 q_shortened = [q_shortened[0], q_shortened[2]]
-            break
+                break
 
         # Sample two points along the path length
         path_scalings = get_normalized_path_scaling(q_shortened)

--- a/src/pyroboplan/planning/path_shortcutting.py
+++ b/src/pyroboplan/planning/path_shortcutting.py
@@ -113,7 +113,7 @@ def shortcut_path(model, collision_model, q_path, max_iters=100, max_step_size=0
         elif len(q_shortened) == 3:
             # If the path has exactly 3 points, try to remove the middle point and return regardless.
             path_to_goal = discretize_joint_space_path(
-                [q_path[0], q_path[2]], max_step_size
+                [q_shortened[0], q_shortened[2]], max_step_size
             )
             if not (check_collisions_along_path(model, collision_model, path_to_goal)):
                 q_shortened = [q_shortened[0], q_shortened[2]]
@@ -136,7 +136,7 @@ def shortcut_path(model, collision_model, q_path, max_iters=100, max_step_size=0
         # Check if the sampled segment is collision free. If it is, shortcut the path.
         path_to_goal = discretize_joint_space_path([q_low, q_high], max_step_size)
         if not check_collisions_along_path(model, collision_model, path_to_goal):
-            q_shortened = (
-                q_shortened[:idx_low] + [q_low, q_high] + q_shortened[idx_high:]
-            )
+            q_shortened[idx_low] = q_low
+            q_shortened[idx_high - 1] = q_high
+            q_shortened = q_shortened[:idx_low] + q_shortened[idx_high - 1 :]
     return q_shortened

--- a/src/pyroboplan/planning/path_shortcutting.py
+++ b/src/pyroboplan/planning/path_shortcutting.py
@@ -107,8 +107,16 @@ def shortcut_path(model, collision_model, q_path, max_iters=100, max_step_size=0
 
     q_shortened = q_path
     for _ in range(max_iters):
-        # If the path has been shortened to 2 points or less, this is already a shortest path.
         if len(q_shortened) < 3:
+            # If the path has been shortened to 2 points or less, this is already a shortest path.
+            break
+        elif len(q_shortened) == 3:
+            # If the path has exactly 3 points, try to remove the middle point and return regardless.
+            path_to_goal = discretize_joint_space_path(
+                [q_path[0], q_path[2]], max_step_size
+            )
+            if not (check_collisions_along_path(model, collision_model, path_to_goal)):
+                q_shortened = [q_shortened[0], q_shortened[2]]
             break
 
         # Sample two points along the path length

--- a/test/planning/test_path_shortcutting.py
+++ b/test/planning/test_path_shortcutting.py
@@ -91,5 +91,6 @@ def test_path_shortcutting():
 
     # Check that the shortened path is shorter than original, but cannot be shorter than a direct path from start to end.
     q_shortened = shortcut_path(model, collision_model, q_path)
+    assert len(q_shortened) <= len(q_path)
     assert get_path_length(q_shortened) <= get_path_length(q_path)
     assert get_path_length(q_shortened) >= get_path_length([q_path[0], q_path[-1]])


### PR DESCRIPTION
Fixes an issue in which a path cannot be shortcut down to exactly 3 points because of probability.

If there are exactly 3 points left, then this has to be a special case that tries to remove just the middle point.

Additionally, the shortcutting was wrong! The path still looked fine when you interpolated it, but the number of points was excessive as it wasn't removing some points that should have been replaced in the first place.